### PR TITLE
Allow constructing money from sub-units.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,16 @@ A Money object can be created with an amount (specified as a string) and a curre
     >>> m
     GBP 9.95
 
+Money objects can also be created from and converted to sub units.
+
+.. code:: python
+
+    >>> m = Money.from_sub_units(499, Currency.USD)
+    >>> m
+    USD 4.99
+    >>> m.sub_units
+    499
+
 Money is immutable and supports most mathematical and logical operators.
 
 .. code:: python

--- a/money/money.py
+++ b/money/money.py
@@ -29,6 +29,18 @@ class Money:
 
         return self._currency
 
+    @classmethod
+    def from_sub_units(cls, sub_units: int, currency: Currency=Currency.USD):
+        """Creates a Money instance from sub-units."""
+        sub_units_per_unit = CurrencyHelper.sub_unit_for_currency(currency)
+        return cls(Decimal(sub_units) / Decimal(sub_units_per_unit), currency)
+
+    @property
+    def sub_units(self) -> int:
+        """Converts the amount to sub-units"""
+        sub_units_per_unit = CurrencyHelper.sub_unit_for_currency(self.currency)
+        return int(self._round(self.amount, self.currency) * sub_units_per_unit)
+
     def __hash__(self) -> str:
         return hash((self._amount, self._currency))
 

--- a/money/money.py
+++ b/money/money.py
@@ -39,7 +39,7 @@ class Money:
     def sub_units(self) -> int:
         """Converts the amount to sub-units"""
         sub_units_per_unit = CurrencyHelper.sub_unit_for_currency(self.currency)
-        return int(self._round(self.amount, self.currency) * sub_units_per_unit)
+        return int(self.amount * sub_units_per_unit)
 
     def __hash__(self) -> str:
         return hash((self._amount, self._currency))

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -7,7 +7,7 @@ from money.currency import Currency
 from money.exceptions import InvalidAmountError, CurrencyMismatchError, InvalidOperandError
 
 # pylint: disable=unneeded-not,expression-not-assigned,no-self-use,missing-docstring
-# pylint: disable=misplaced-comparison-constant,singleton-comparison
+# pylint: disable=misplaced-comparison-constant,singleton-comparison,too-many-public-methods
 
 class TestMoney:
     """Money tests"""

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -36,6 +36,17 @@ class TestMoney:
             # nonfractional currency
             Money('10.2', Currency.KRW)
 
+    def test_from_sub_units(self):
+        money = Money.from_sub_units(101, Currency.USD)
+        assert money == Money('1.01', Currency.USD)
+
+        money = Money.from_sub_units(5, Currency.JPY)
+        assert money == Money('5', Currency.JPY)
+
+    def test_sub_units(self):
+        money = Money('1.01', Currency.USD)
+        assert money.sub_units == 101
+
     def test_hash(self):
         assert hash(Money('1.2')) == hash(Money('1.2', Currency.USD))
         assert hash(Money('1.5')) != hash(Money('9.3'))


### PR DESCRIPTION
Hi all,

I have added a pair of methods for working with sub-units that can come in handy for those storing money in sub units.

```python
price = Money.from_sub_units(101, Currency.USD)  # $1.01 USD
total = price * 2
total.sub_units  # 202 (cents)
```
Thank you for crafting this library and reviewing this PR.

-R