### PR TITLE
Allow more versions of babel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=[
         'money'
     ],
-    version='0.3.0',
+    version='0.4.0',
     description='Money module for python',
     long_description=long_description,
     url='https://github.com/vimeo/py-money',
@@ -27,6 +27,6 @@ setup(
     ],
     keywords='money currency',
     install_requires=[
-        'babel==2.4.0'
+        'babel >= 2.4.0, < 3.0'
     ],
 )


### PR DESCRIPTION
Assuming babel follows good semantic versioning, we should allow 2.4 up to (but not including) 3.

Fixes #7 