### PR TITLE
Fix BYR subunits and add new BYN currency

### DIFF
--- a/money/currency.py
+++ b/money/currency.py
@@ -32,6 +32,7 @@ class Currency(Enum):
     BTN = 'BTN'
     BWP = 'BWP'
     BYR = 'BYR'
+    BYN = 'BYN'
     BZD = 'BZD'
     CAD = 'CAD'
     CDF = 'CDF'
@@ -338,9 +339,15 @@ class CurrencyHelper:
             'sub_unit': 100,
         },
         Currency.BYR: {
-            'display_name': 'Belarussian Ruble',
+            'display_name': 'Belarusian Ruble',
             'numeric_code': 974,
             'default_fraction_digits': 0,
+            'sub_unit': 1,
+        },
+        Currency.BYN: {
+            'display_name': 'Belarusian Ruble',
+            'numeric_code': 933,
+            'default_fraction_digits': 2,
             'sub_unit': 100,
         },
         Currency.BZD: {


### PR DESCRIPTION
The correct ISO 4217 currency name is **Belarusian Ruble**.
And also `BYR` currency subunits should be `1`, `BYN` currency subunits should be `100`.

---

Wiki:

- https://en.wikipedia.org/wiki/Belarusian_ruble
- https://en.wikipedia.org/wiki/ISO_4217