### PR TITLE
Refactor currency enum, add currency format method

### DIFF
--- a/money/currency.py
+++ b/money/currency.py
@@ -1,1308 +1,1131 @@
 """Module defining currencies and currency utilities"""
 
 from enum import Enum
+from typing import Any, Dict
 
-#pylint: disable=too-many-lines
+from babel.numbers import get_currency_symbol
 
-class Currency(Enum):
-    """Enumerates all supported currencies"""
+# pylint: disable=too-many-lines
 
-    AED = 'AED'
-    AFN = 'AFN'
-    ALL = 'ALL'
-    AMD = 'AMD'
-    ANG = 'ANG'
-    AOA = 'AOA'
-    ARS = 'ARS'
-    AUD = 'AUD'
-    AWG = 'AWG'
-    AZN = 'AZN'
-    BAM = 'BAM'
-    BBD = 'BBD'
-    BDT = 'BDT'
-    BGN = 'BGN'
-    BHD = 'BHD'
-    BIF = 'BIF'
-    BMD = 'BMD'
-    BND = 'BND'
-    BOB = 'BOB'
-    BOV = 'BOV'
-    BRL = 'BRL'
-    BSD = 'BSD'
-    BTN = 'BTN'
-    BWP = 'BWP'
-    BYR = 'BYR'
-    BYN = 'BYN'
-    BZD = 'BZD'
-    CAD = 'CAD'
-    CDF = 'CDF'
-    CHE = 'CHE'
-    CHF = 'CHF'
-    CHW = 'CHW'
-    CLF = 'CLF'
-    CLP = 'CLP'
-    CNY = 'CNY'
-    COP = 'COP'
-    COU = 'COU'
-    CRC = 'CRC'
-    CUC = 'CUC'
-    CUP = 'CUP'
-    CVE = 'CVE'
-    CZK = 'CZK'
-    DJF = 'DJF'
-    DKK = 'DKK'
-    DOP = 'DOP'
-    DZD = 'DZD'
-    EGP = 'EGP'
-    ERN = 'ERN'
-    ETB = 'ETB'
-    EUR = 'EUR'
-    FJD = 'FJD'
-    FKP = 'FKP'
-    GBP = 'GBP'
-    GEL = 'GEL'
-    GHS = 'GHS'
-    GIP = 'GIP'
-    GMD = 'GMD'
-    GNF = 'GNF'
-    GTQ = 'GTQ'
-    GYD = 'GYD'
-    HKD = 'HKD'
-    HNL = 'HNL'
-    HRK = 'HRK'
-    HTG = 'HTG'
-    HUF = 'HUF'
-    IDR = 'IDR'
-    ILS = 'ILS'
-    INR = 'INR'
-    IQD = 'IQD'
-    IRR = 'IRR'
-    ISK = 'ISK'
-    JMD = 'JMD'
-    JOD = 'JOD'
-    JPY = 'JPY'
-    KES = 'KES'
-    KGS = 'KGS'
-    KHR = 'KHR'
-    KMF = 'KMF'
-    KPW = 'KPW'
-    KRW = 'KRW'
-    KWD = 'KWD'
-    KYD = 'KYD'
-    KZT = 'KZT'
-    LAK = 'LAK'
-    LBP = 'LBP'
-    LKR = 'LKR'
-    LRD = 'LRD'
-    LSL = 'LSL'
-    LTL = 'LTL'
-    LVL = 'LVL'
-    LYD = 'LYD'
-    MAD = 'MAD'
-    MDL = 'MDL'
-    MGA = 'MGA'
-    MKD = 'MKD'
-    MMK = 'MMK'
-    MNT = 'MNT'
-    MOP = 'MOP'
-    MRO = 'MRO'
-    MUR = 'MUR'
-    MVR = 'MVR'
-    MWK = 'MWK'
-    MXN = 'MXN'
-    MXV = 'MXV'
-    MYR = 'MYR'
-    MZN = 'MZN'
-    NAD = 'NAD'
-    NGN = 'NGN'
-    NIO = 'NIO'
-    NOK = 'NOK'
-    NPR = 'NPR'
-    NZD = 'NZD'
-    OMR = 'OMR'
-    PAB = 'PAB'
-    PEN = 'PEN'
-    PGK = 'PGK'
-    PHP = 'PHP'
-    PKR = 'PKR'
-    PLN = 'PLN'
-    PYG = 'PYG'
-    QAR = 'QAR'
-    RON = 'RON'
-    RSD = 'RSD'
-    RUB = 'RUB'
-    RWF = 'RWF'
-    SAR = 'SAR'
-    SBD = 'SBD'
-    SCR = 'SCR'
-    SDG = 'SDG'
-    SEK = 'SEK'
-    SGD = 'SGD'
-    SHP = 'SHP'
-    SLL = 'SLL'
-    SOS = 'SOS'
-    SRD = 'SRD'
-    SSP = 'SSP'
-    STD = 'STD'
-    SVC = 'SVC'
-    SYP = 'SYP'
-    SZL = 'SZL'
-    THB = 'THB'
-    TJS = 'TJS'
-    TMT = 'TMT'
-    TND = 'TND'
-    TOP = 'TOP'
-    TRY = 'TRY'
-    TTD = 'TTD'
-    TWD = 'TWD'
-    TZS = 'TZS'
-    UAH = 'UAH'
-    UGX = 'UGX'
-    USD = 'USD'
-    USN = 'USN'
-    USS = 'USS'
-    UYI = 'UYI'
-    UYU = 'UYU'
-    UZS = 'UZS'
-    VEF = 'VEF'
-    VND = 'VND'
-    VUV = 'VUV'
-    WST = 'WST'
-    XAF = 'XAF'
-    XAG = 'XAG'
-    XAU = 'XAU'
-    XBA = 'XBA'
-    XBB = 'XBB'
-    XBC = 'XBC'
-    XBD = 'XBD'
-    XCD = 'XCD'
-    XDR = 'XDR'
-    XFU = 'XFU'
-    XOF = 'XOF'
-    XPD = 'XPD'
-    XPF = 'XPF'
-    XPT = 'XPT'
-    XSU = 'XSU'
-    XTS = 'XTS'
-    XUA = 'XUA'
-    YER = 'YER'
-    ZAR = 'ZAR'
-    ZMW = 'ZMW'
-    ZWL = 'ZWL'
+"""
+Data about currencies.
+Taken from https://github.com/sebastianbergmann/money
+"""
+_CURRENCY_DATA = {
+    "AED": {
+        "display_name": "UAE Dirham",
+        "numeric_code": 784,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "AFN": {
+        "display_name": "Afghani",
+        "numeric_code": 971,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ALL": {
+        "display_name": "Lek",
+        "numeric_code": 8,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "AMD": {
+        "display_name": "Armenian Dram",
+        "numeric_code": 51,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ANG": {
+        "display_name": "Netherlands Antillean Guilder",
+        "numeric_code": 532,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "AOA": {
+        "display_name": "Kwanza",
+        "numeric_code": 973,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ARS": {
+        "display_name": "Argentine Peso",
+        "numeric_code": 32,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "AUD": {
+        "display_name": "Australian Dollar",
+        "numeric_code": 36,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "AWG": {
+        "display_name": "Aruban Florin",
+        "numeric_code": 533,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "AZN": {
+        "display_name": "Azerbaijanian Manat",
+        "numeric_code": 944,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BAM": {
+        "display_name": "Convertible Mark",
+        "numeric_code": 977,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BBD": {
+        "display_name": "Barbados Dollar",
+        "numeric_code": 52,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BDT": {
+        "display_name": "Taka",
+        "numeric_code": 50,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BGN": {
+        "display_name": "Bulgarian Lev",
+        "numeric_code": 975,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BHD": {
+        "display_name": "Bahraini Dinar",
+        "numeric_code": 48,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "BIF": {
+        "display_name": "Burundi Franc",
+        "numeric_code": 108,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "BMD": {
+        "display_name": "Bermudian Dollar",
+        "numeric_code": 60,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BND": {
+        "display_name": "Brunei Dollar",
+        "numeric_code": 96,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BOB": {
+        "display_name": "Boliviano",
+        "numeric_code": 68,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BOV": {
+        "display_name": "Mvdol",
+        "numeric_code": 984,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BRL": {
+        "display_name": "Brazilian Real",
+        "numeric_code": 986,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BSD": {
+        "display_name": "Bahamian Dollar",
+        "numeric_code": 44,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BTN": {
+        "display_name": "Ngultrum",
+        "numeric_code": 64,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BWP": {
+        "display_name": "Pula",
+        "numeric_code": 72,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BYR": {
+        "display_name": "Belarusian Ruble",
+        "numeric_code": 974,
+        "default_fraction_digits": 0,
+        "sub_unit": 1,
+    },
+    "BYN": {
+        "display_name": "Belarusian Ruble",
+        "numeric_code": 933,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "BZD": {
+        "display_name": "Belize Dollar",
+        "numeric_code": 84,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CAD": {
+        "display_name": "Canadian Dollar",
+        "numeric_code": 124,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CDF": {
+        "display_name": "Congolese Franc",
+        "numeric_code": 976,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CHE": {
+        "display_name": "WIR Euro",
+        "numeric_code": 947,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CHF": {
+        "display_name": "Swiss Franc",
+        "numeric_code": 756,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CHW": {
+        "display_name": "WIR Franc",
+        "numeric_code": 948,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CLF": {
+        "display_name": "Unidades de fomento",
+        "numeric_code": 990,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "CLP": {
+        "display_name": "Chilean Peso",
+        "numeric_code": 152,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "CNY": {
+        "display_name": "Yuan Renminbi",
+        "numeric_code": 156,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "COP": {
+        "display_name": "Colombian Peso",
+        "numeric_code": 170,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "COU": {
+        "display_name": "Unidad de Valor Real",
+        "numeric_code": 970,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CRC": {
+        "display_name": "Costa Rican Colon",
+        "numeric_code": 188,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CUC": {
+        "display_name": "Peso Convertible",
+        "numeric_code": 931,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CUP": {
+        "display_name": "Cuban Peso",
+        "numeric_code": 192,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CVE": {
+        "display_name": "Cape Verde Escudo",
+        "numeric_code": 132,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "CZK": {
+        "display_name": "Czech Koruna",
+        "numeric_code": 203,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "DJF": {
+        "display_name": "Djibouti Franc",
+        "numeric_code": 262,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "DKK": {
+        "display_name": "Danish Krone",
+        "numeric_code": 208,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "DOP": {
+        "display_name": "Dominican Peso",
+        "numeric_code": 214,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "DZD": {
+        "display_name": "Algerian Dinar",
+        "numeric_code": 12,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "EGP": {
+        "display_name": "Egyptian Pound",
+        "numeric_code": 818,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ERN": {
+        "display_name": "Nakfa",
+        "numeric_code": 232,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ETB": {
+        "display_name": "Ethiopian Birr",
+        "numeric_code": 230,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "EUR": {
+        "display_name": "Euro",
+        "numeric_code": 978,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "FJD": {
+        "display_name": "Fiji Dollar",
+        "numeric_code": 242,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "FKP": {
+        "display_name": "Falkland Islands Pound",
+        "numeric_code": 238,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GBP": {
+        "display_name": "Pound Sterling",
+        "numeric_code": 826,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GEL": {
+        "display_name": "Lari",
+        "numeric_code": 981,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GHS": {
+        "display_name": "Ghana Cedi",
+        "numeric_code": 936,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GIP": {
+        "display_name": "Gibraltar Pound",
+        "numeric_code": 292,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GMD": {
+        "display_name": "Dalasi",
+        "numeric_code": 270,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GNF": {
+        "display_name": "Guinea Franc",
+        "numeric_code": 324,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "GTQ": {
+        "display_name": "Quetzal",
+        "numeric_code": 320,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "GYD": {
+        "display_name": "Guyana Dollar",
+        "numeric_code": 328,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "HKD": {
+        "display_name": "Hong Kong Dollar",
+        "numeric_code": 344,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "HNL": {
+        "display_name": "Lempira",
+        "numeric_code": 340,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "HRK": {
+        "display_name": "Croatian Kuna",
+        "numeric_code": 191,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "HTG": {
+        "display_name": "Gourde",
+        "numeric_code": 332,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "HUF": {
+        "display_name": "Forint",
+        "numeric_code": 348,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "IDR": {
+        "display_name": "Rupiah",
+        "numeric_code": 360,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ILS": {
+        "display_name": "New Israeli Sheqel",
+        "numeric_code": 376,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "INR": {
+        "display_name": "Indian Rupee",
+        "numeric_code": 356,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "IQD": {
+        "display_name": "Iraqi Dinar",
+        "numeric_code": 368,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "IRR": {
+        "display_name": "Iranian Rial",
+        "numeric_code": 364,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ISK": {
+        "display_name": "Iceland Krona",
+        "numeric_code": 352,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "JMD": {
+        "display_name": "Jamaican Dollar",
+        "numeric_code": 388,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "JOD": {
+        "display_name": "Jordanian Dinar",
+        "numeric_code": 400,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "JPY": {
+        "display_name": "Yen",
+        "numeric_code": 392,
+        "default_fraction_digits": 0,
+        "sub_unit": 1,
+    },
+    "KES": {
+        "display_name": "Kenyan Shilling",
+        "numeric_code": 404,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "KGS": {
+        "display_name": "Som",
+        "numeric_code": 417,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "KHR": {
+        "display_name": "Riel",
+        "numeric_code": 116,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "KMF": {
+        "display_name": "Comoro Franc",
+        "numeric_code": 174,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "KPW": {
+        "display_name": "North Korean Won",
+        "numeric_code": 408,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "KRW": {
+        "display_name": "Won",
+        "numeric_code": 410,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "KWD": {
+        "display_name": "Kuwaiti Dinar",
+        "numeric_code": 414,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "KYD": {
+        "display_name": "Cayman Islands Dollar",
+        "numeric_code": 136,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "KZT": {
+        "display_name": "Tenge",
+        "numeric_code": 398,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LAK": {
+        "display_name": "Kip",
+        "numeric_code": 418,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LBP": {
+        "display_name": "Lebanese Pound",
+        "numeric_code": 422,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LKR": {
+        "display_name": "Sri Lanka Rupee",
+        "numeric_code": 144,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LRD": {
+        "display_name": "Liberian Dollar",
+        "numeric_code": 430,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LSL": {
+        "display_name": "Loti",
+        "numeric_code": 426,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LTL": {
+        "display_name": "Lithuanian Litas",
+        "numeric_code": 440,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LVL": {
+        "display_name": "Latvian Lats",
+        "numeric_code": 428,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "LYD": {
+        "display_name": "Libyan Dinar",
+        "numeric_code": 434,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "MAD": {
+        "display_name": "Moroccan Dirham",
+        "numeric_code": 504,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MDL": {
+        "display_name": "Moldovan Leu",
+        "numeric_code": 498,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MGA": {
+        "display_name": "Malagasy Ariary",
+        "numeric_code": 969,
+        "default_fraction_digits": 2,
+        "sub_unit": 5,
+    },
+    "MKD": {
+        "display_name": "Denar",
+        "numeric_code": 807,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MMK": {
+        "display_name": "Kyat",
+        "numeric_code": 104,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MNT": {
+        "display_name": "Tugrik",
+        "numeric_code": 496,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MOP": {
+        "display_name": "Pataca",
+        "numeric_code": 446,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MRO": {
+        "display_name": "Ouguiya",
+        "numeric_code": 478,
+        "default_fraction_digits": 2,
+        "sub_unit": 5,
+    },
+    "MUR": {
+        "display_name": "Mauritius Rupee",
+        "numeric_code": 480,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MVR": {
+        "display_name": "Rufiyaa",
+        "numeric_code": 462,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MWK": {
+        "display_name": "Kwacha",
+        "numeric_code": 454,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MXN": {
+        "display_name": "Mexican Peso",
+        "numeric_code": 484,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MXV": {
+        "display_name": "Mexican Unidad de Inversion (UDI)",
+        "numeric_code": 979,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MYR": {
+        "display_name": "Malaysian Ringgit",
+        "numeric_code": 458,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "MZN": {
+        "display_name": "Mozambique Metical",
+        "numeric_code": 943,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "NAD": {
+        "display_name": "Namibia Dollar",
+        "numeric_code": 516,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "NGN": {
+        "display_name": "Naira",
+        "numeric_code": 566,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "NIO": {
+        "display_name": "Cordoba Oro",
+        "numeric_code": 558,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "NOK": {
+        "display_name": "Norwegian Krone",
+        "numeric_code": 578,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "NPR": {
+        "display_name": "Nepalese Rupee",
+        "numeric_code": 524,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "NZD": {
+        "display_name": "New Zealand Dollar",
+        "numeric_code": 554,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "OMR": {
+        "display_name": "Rial Omani",
+        "numeric_code": 512,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "PAB": {
+        "display_name": "Balboa",
+        "numeric_code": 590,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "PEN": {
+        "display_name": "Nuevo Sol",
+        "numeric_code": 604,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "PGK": {
+        "display_name": "Kina",
+        "numeric_code": 598,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "PHP": {
+        "display_name": "Philippine Peso",
+        "numeric_code": 608,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "PKR": {
+        "display_name": "Pakistan Rupee",
+        "numeric_code": 586,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "PLN": {
+        "display_name": "Zloty",
+        "numeric_code": 985,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "PYG": {
+        "display_name": "Guarani",
+        "numeric_code": 600,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "QAR": {
+        "display_name": "Qatari Rial",
+        "numeric_code": 634,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "RON": {
+        "display_name": "New Romanian Leu",
+        "numeric_code": 946,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "RSD": {
+        "display_name": "Serbian Dinar",
+        "numeric_code": 941,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "RUB": {
+        "display_name": "Russian Ruble",
+        "numeric_code": 643,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "RWF": {
+        "display_name": "Rwanda Franc",
+        "numeric_code": 646,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "SAR": {
+        "display_name": "Saudi Riyal",
+        "numeric_code": 682,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SBD": {
+        "display_name": "Solomon Islands Dollar",
+        "numeric_code": 90,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SCR": {
+        "display_name": "Seychelles Rupee",
+        "numeric_code": 690,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SDG": {
+        "display_name": "Sudanese Pound",
+        "numeric_code": 938,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SEK": {
+        "display_name": "Swedish Krona",
+        "numeric_code": 752,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SGD": {
+        "display_name": "Singapore Dollar",
+        "numeric_code": 702,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SHP": {
+        "display_name": "Saint Helena Pound",
+        "numeric_code": 654,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SLL": {
+        "display_name": "Leone",
+        "numeric_code": 694,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SOS": {
+        "display_name": "Somali Shilling",
+        "numeric_code": 706,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SRD": {
+        "display_name": "Surinam Dollar",
+        "numeric_code": 968,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SSP": {
+        "display_name": "South Sudanese Pound",
+        "numeric_code": 728,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "STD": {
+        "display_name": "Dobra",
+        "numeric_code": 678,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SVC": {
+        "display_name": "El Salvador Colon",
+        "numeric_code": 222,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SYP": {
+        "display_name": "Syrian Pound",
+        "numeric_code": 760,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "SZL": {
+        "display_name": "Lilangeni",
+        "numeric_code": 748,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "THB": {
+        "display_name": "Baht",
+        "numeric_code": 764,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TJS": {
+        "display_name": "Somoni",
+        "numeric_code": 972,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TMT": {
+        "display_name": "Turkmenistan New Manat",
+        "numeric_code": 934,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TND": {
+        "display_name": "Tunisian Dinar",
+        "numeric_code": 788,
+        "default_fraction_digits": 3,
+        "sub_unit": 1000,
+    },
+    "TOP": {
+        "display_name": "Pa’anga",
+        "numeric_code": 776,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TRY": {
+        "display_name": "Turkish Lira",
+        "numeric_code": 949,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TTD": {
+        "display_name": "Trinidad and Tobago Dollar",
+        "numeric_code": 780,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TWD": {
+        "display_name": "New Taiwan Dollar",
+        "numeric_code": 901,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "TZS": {
+        "display_name": "Tanzanian Shilling",
+        "numeric_code": 834,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "UAH": {
+        "display_name": "Hryvnia",
+        "numeric_code": 980,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "UGX": {
+        "display_name": "Uganda Shilling",
+        "numeric_code": 800,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "USD": {
+        "display_name": "US Dollar",
+        "numeric_code": 840,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "USN": {
+        "display_name": "US Dollar (Next day)",
+        "numeric_code": 997,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "USS": {
+        "display_name": "US Dollar (Same day)",
+        "numeric_code": 998,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "UYI": {
+        "display_name": "Uruguay Peso en Unidades Indexadas (URUIURUI)",
+        "numeric_code": 940,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "UYU": {
+        "display_name": "Peso Uruguayo",
+        "numeric_code": 858,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "UZS": {
+        "display_name": "Uzbekistan Sum",
+        "numeric_code": 860,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "VEF": {
+        "display_name": "Bolivar",
+        "numeric_code": 937,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "VND": {
+        "display_name": "Dong",
+        "numeric_code": 704,
+        "default_fraction_digits": 0,
+        "sub_unit": 10,
+    },
+    "VUV": {
+        "display_name": "Vatu",
+        "numeric_code": 548,
+        "default_fraction_digits": 0,
+        "sub_unit": 1,
+    },
+    "WST": {
+        "display_name": "Tala",
+        "numeric_code": 882,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "XAF": {
+        "display_name": "CFA Franc BEAC",
+        "numeric_code": 950,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XAG": {
+        "display_name": "Silver",
+        "numeric_code": 961,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XAU": {
+        "display_name": "Gold",
+        "numeric_code": 959,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XBA": {
+        "display_name": "Bond Markets Unit European Composite Unit (EURCO)",
+        "numeric_code": 955,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XBB": {
+        "display_name": "Bond Markets Unit European Monetary Unit (E.M.U.-6)",
+        "numeric_code": 956,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XBC": {
+        "display_name": "Bond Markets Unit European Unit of Account 9 (E.U.A.-9)",
+        "numeric_code": 957,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XBD": {
+        "display_name": "Bond Markets Unit European Unit of Account 17 (E.U.A.-17)",
+        "numeric_code": 958,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XCD": {
+        "display_name": "East Caribbean Dollar",
+        "numeric_code": 951,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "XDR": {
+        "display_name": "SDR (Special Drawing Right)",
+        "numeric_code": 960,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XFU": {
+        "display_name": "UIC-Franc",
+        "numeric_code": 958,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XOF": {
+        "display_name": "CFA Franc BCEAO",
+        "numeric_code": 952,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XPD": {
+        "display_name": "Palladium",
+        "numeric_code": 964,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XPF": {
+        "display_name": "CFP Franc",
+        "numeric_code": 953,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XPT": {
+        "display_name": "Platinum",
+        "numeric_code": 962,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XSU": {
+        "display_name": "Sucre",
+        "numeric_code": 994,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XTS": {
+        "display_name": "Codes specifically reserved for testing purposes",
+        "numeric_code": 963,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "XUA": {
+        "display_name": "ADB Unit of Account",
+        "numeric_code": 965,
+        "default_fraction_digits": 0,
+        "sub_unit": 100,
+    },
+    "YER": {
+        "display_name": "Yemeni Rial",
+        "numeric_code": 886,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ZAR": {
+        "display_name": "Rand",
+        "numeric_code": 710,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ZMW": {
+        "display_name": "Zambian Kwacha",
+        "numeric_code": 967,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+    "ZWL": {
+        "display_name": "Zimbabwe Dollar",
+        "numeric_code": 932,
+        "default_fraction_digits": 2,
+        "sub_unit": 100,
+    },
+}
 
-class CurrencyHelper:
-    """Utilities for currencies"""
 
-    _CURRENCY_DATA = {
-        Currency.AED: {
-            'display_name': 'UAE Dirham',
-            'numeric_code': 784,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.AFN: {
-            'display_name': 'Afghani',
-            'numeric_code': 971,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ALL: {
-            'display_name': 'Lek',
-            'numeric_code': 8,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.AMD: {
-            'display_name': 'Armenian Dram',
-            'numeric_code': 51,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ANG: {
-            'display_name': 'Netherlands Antillean Guilder',
-            'numeric_code': 532,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.AOA: {
-            'display_name': 'Kwanza',
-            'numeric_code': 973,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ARS: {
-            'display_name': 'Argentine Peso',
-            'numeric_code': 32,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.AUD: {
-            'display_name': 'Australian Dollar',
-            'numeric_code': 36,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.AWG: {
-            'display_name': 'Aruban Florin',
-            'numeric_code': 533,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.AZN: {
-            'display_name': 'Azerbaijanian Manat',
-            'numeric_code': 944,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BAM: {
-            'display_name': 'Convertible Mark',
-            'numeric_code': 977,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BBD: {
-            'display_name': 'Barbados Dollar',
-            'numeric_code': 52,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BDT: {
-            'display_name': 'Taka',
-            'numeric_code': 50,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BGN: {
-            'display_name': 'Bulgarian Lev',
-            'numeric_code': 975,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BHD: {
-            'display_name': 'Bahraini Dinar',
-            'numeric_code': 48,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.BIF: {
-            'display_name': 'Burundi Franc',
-            'numeric_code': 108,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.BMD: {
-            'display_name': 'Bermudian Dollar',
-            'numeric_code': 60,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BND: {
-            'display_name': 'Brunei Dollar',
-            'numeric_code': 96,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BOB: {
-            'display_name': 'Boliviano',
-            'numeric_code': 68,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BOV: {
-            'display_name': 'Mvdol',
-            'numeric_code': 984,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BRL: {
-            'display_name': 'Brazilian Real',
-            'numeric_code': 986,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BSD: {
-            'display_name': 'Bahamian Dollar',
-            'numeric_code': 44,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BTN: {
-            'display_name': 'Ngultrum',
-            'numeric_code': 64,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BWP: {
-            'display_name': 'Pula',
-            'numeric_code': 72,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BYR: {
-            'display_name': 'Belarusian Ruble',
-            'numeric_code': 974,
-            'default_fraction_digits': 0,
-            'sub_unit': 1,
-        },
-        Currency.BYN: {
-            'display_name': 'Belarusian Ruble',
-            'numeric_code': 933,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.BZD: {
-            'display_name': 'Belize Dollar',
-            'numeric_code': 84,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CAD: {
-            'display_name': 'Canadian Dollar',
-            'numeric_code': 124,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CDF: {
-            'display_name': 'Congolese Franc',
-            'numeric_code': 976,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CHE: {
-            'display_name': 'WIR Euro',
-            'numeric_code': 947,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CHF: {
-            'display_name': 'Swiss Franc',
-            'numeric_code': 756,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CHW: {
-            'display_name': 'WIR Franc',
-            'numeric_code': 948,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CLF: {
-            'display_name': 'Unidades de fomento',
-            'numeric_code': 990,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.CLP: {
-            'display_name': 'Chilean Peso',
-            'numeric_code': 152,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.CNY: {
-            'display_name': 'Yuan Renminbi',
-            'numeric_code': 156,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.COP: {
-            'display_name': 'Colombian Peso',
-            'numeric_code': 170,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.COU: {
-            'display_name': 'Unidad de Valor Real',
-            'numeric_code': 970,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CRC: {
-            'display_name': 'Costa Rican Colon',
-            'numeric_code': 188,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CUC: {
-            'display_name': 'Peso Convertible',
-            'numeric_code': 931,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CUP: {
-            'display_name': 'Cuban Peso',
-            'numeric_code': 192,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CVE: {
-            'display_name': 'Cape Verde Escudo',
-            'numeric_code': 132,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.CZK: {
-            'display_name': 'Czech Koruna',
-            'numeric_code': 203,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.DJF: {
-            'display_name': 'Djibouti Franc',
-            'numeric_code': 262,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.DKK: {
-            'display_name': 'Danish Krone',
-            'numeric_code': 208,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.DOP: {
-            'display_name': 'Dominican Peso',
-            'numeric_code': 214,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.DZD: {
-            'display_name': 'Algerian Dinar',
-            'numeric_code': 12,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.EGP: {
-            'display_name': 'Egyptian Pound',
-            'numeric_code': 818,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ERN: {
-            'display_name': 'Nakfa',
-            'numeric_code': 232,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ETB: {
-            'display_name': 'Ethiopian Birr',
-            'numeric_code': 230,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.EUR: {
-            'display_name': 'Euro',
-            'numeric_code': 978,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.FJD: {
-            'display_name': 'Fiji Dollar',
-            'numeric_code': 242,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.FKP: {
-            'display_name': 'Falkland Islands Pound',
-            'numeric_code': 238,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GBP: {
-            'display_name': 'Pound Sterling',
-            'numeric_code': 826,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GEL: {
-            'display_name': 'Lari',
-            'numeric_code': 981,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GHS: {
-            'display_name': 'Ghana Cedi',
-            'numeric_code': 936,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GIP: {
-            'display_name': 'Gibraltar Pound',
-            'numeric_code': 292,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GMD: {
-            'display_name': 'Dalasi',
-            'numeric_code': 270,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GNF: {
-            'display_name': 'Guinea Franc',
-            'numeric_code': 324,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.GTQ: {
-            'display_name': 'Quetzal',
-            'numeric_code': 320,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.GYD: {
-            'display_name': 'Guyana Dollar',
-            'numeric_code': 328,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.HKD: {
-            'display_name': 'Hong Kong Dollar',
-            'numeric_code': 344,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.HNL: {
-            'display_name': 'Lempira',
-            'numeric_code': 340,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.HRK: {
-            'display_name': 'Croatian Kuna',
-            'numeric_code': 191,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.HTG: {
-            'display_name': 'Gourde',
-            'numeric_code': 332,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.HUF: {
-            'display_name': 'Forint',
-            'numeric_code': 348,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.IDR: {
-            'display_name': 'Rupiah',
-            'numeric_code': 360,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ILS: {
-            'display_name': 'New Israeli Sheqel',
-            'numeric_code': 376,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.INR: {
-            'display_name': 'Indian Rupee',
-            'numeric_code': 356,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.IQD: {
-            'display_name': 'Iraqi Dinar',
-            'numeric_code': 368,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.IRR: {
-            'display_name': 'Iranian Rial',
-            'numeric_code': 364,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ISK: {
-            'display_name': 'Iceland Krona',
-            'numeric_code': 352,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.JMD: {
-            'display_name': 'Jamaican Dollar',
-            'numeric_code': 388,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.JOD: {
-            'display_name': 'Jordanian Dinar',
-            'numeric_code': 400,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.JPY: {
-            'display_name': 'Yen',
-            'numeric_code': 392,
-            'default_fraction_digits': 0,
-            'sub_unit': 1,
-        },
-        Currency.KES: {
-            'display_name': 'Kenyan Shilling',
-            'numeric_code': 404,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.KGS: {
-            'display_name': 'Som',
-            'numeric_code': 417,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.KHR: {
-            'display_name': 'Riel',
-            'numeric_code': 116,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.KMF: {
-            'display_name': 'Comoro Franc',
-            'numeric_code': 174,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.KPW: {
-            'display_name': 'North Korean Won',
-            'numeric_code': 408,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.KRW: {
-            'display_name': 'Won',
-            'numeric_code': 410,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.KWD: {
-            'display_name': 'Kuwaiti Dinar',
-            'numeric_code': 414,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.KYD: {
-            'display_name': 'Cayman Islands Dollar',
-            'numeric_code': 136,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.KZT: {
-            'display_name': 'Tenge',
-            'numeric_code': 398,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LAK: {
-            'display_name': 'Kip',
-            'numeric_code': 418,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LBP: {
-            'display_name': 'Lebanese Pound',
-            'numeric_code': 422,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LKR: {
-            'display_name': 'Sri Lanka Rupee',
-            'numeric_code': 144,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LRD: {
-            'display_name': 'Liberian Dollar',
-            'numeric_code': 430,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LSL: {
-            'display_name': 'Loti',
-            'numeric_code': 426,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LTL: {
-            'display_name': 'Lithuanian Litas',
-            'numeric_code': 440,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LVL: {
-            'display_name': 'Latvian Lats',
-            'numeric_code': 428,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.LYD: {
-            'display_name': 'Libyan Dinar',
-            'numeric_code': 434,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.MAD: {
-            'display_name': 'Moroccan Dirham',
-            'numeric_code': 504,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MDL: {
-            'display_name': 'Moldovan Leu',
-            'numeric_code': 498,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MGA: {
-            'display_name': 'Malagasy Ariary',
-            'numeric_code': 969,
-            'default_fraction_digits': 2,
-            'sub_unit': 5,
-        },
-        Currency.MKD: {
-            'display_name': 'Denar',
-            'numeric_code': 807,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MMK: {
-            'display_name': 'Kyat',
-            'numeric_code': 104,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MNT: {
-            'display_name': 'Tugrik',
-            'numeric_code': 496,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MOP: {
-            'display_name': 'Pataca',
-            'numeric_code': 446,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MRO: {
-            'display_name': 'Ouguiya',
-            'numeric_code': 478,
-            'default_fraction_digits': 2,
-            'sub_unit': 5,
-        },
-        Currency.MUR: {
-            'display_name': 'Mauritius Rupee',
-            'numeric_code': 480,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MVR: {
-            'display_name': 'Rufiyaa',
-            'numeric_code': 462,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MWK: {
-            'display_name': 'Kwacha',
-            'numeric_code': 454,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MXN: {
-            'display_name': 'Mexican Peso',
-            'numeric_code': 484,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MXV: {
-            'display_name': 'Mexican Unidad de Inversion (UDI)',
-            'numeric_code': 979,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MYR: {
-            'display_name': 'Malaysian Ringgit',
-            'numeric_code': 458,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.MZN: {
-            'display_name': 'Mozambique Metical',
-            'numeric_code': 943,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.NAD: {
-            'display_name': 'Namibia Dollar',
-            'numeric_code': 516,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.NGN: {
-            'display_name': 'Naira',
-            'numeric_code': 566,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.NIO: {
-            'display_name': 'Cordoba Oro',
-            'numeric_code': 558,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.NOK: {
-            'display_name': 'Norwegian Krone',
-            'numeric_code': 578,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.NPR: {
-            'display_name': 'Nepalese Rupee',
-            'numeric_code': 524,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.NZD: {
-            'display_name': 'New Zealand Dollar',
-            'numeric_code': 554,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.OMR: {
-            'display_name': 'Rial Omani',
-            'numeric_code': 512,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.PAB: {
-            'display_name': 'Balboa',
-            'numeric_code': 590,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.PEN: {
-            'display_name': 'Nuevo Sol',
-            'numeric_code': 604,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.PGK: {
-            'display_name': 'Kina',
-            'numeric_code': 598,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.PHP: {
-            'display_name': 'Philippine Peso',
-            'numeric_code': 608,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.PKR: {
-            'display_name': 'Pakistan Rupee',
-            'numeric_code': 586,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.PLN: {
-            'display_name': 'Zloty',
-            'numeric_code': 985,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.PYG: {
-            'display_name': 'Guarani',
-            'numeric_code': 600,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.QAR: {
-            'display_name': 'Qatari Rial',
-            'numeric_code': 634,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.RON: {
-            'display_name': 'New Romanian Leu',
-            'numeric_code': 946,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.RSD: {
-            'display_name': 'Serbian Dinar',
-            'numeric_code': 941,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.RUB: {
-            'display_name': 'Russian Ruble',
-            'numeric_code': 643,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.RWF: {
-            'display_name': 'Rwanda Franc',
-            'numeric_code': 646,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.SAR: {
-            'display_name': 'Saudi Riyal',
-            'numeric_code': 682,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SBD: {
-            'display_name': 'Solomon Islands Dollar',
-            'numeric_code': 90,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SCR: {
-            'display_name': 'Seychelles Rupee',
-            'numeric_code': 690,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SDG: {
-            'display_name': 'Sudanese Pound',
-            'numeric_code': 938,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SEK: {
-            'display_name': 'Swedish Krona',
-            'numeric_code': 752,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SGD: {
-            'display_name': 'Singapore Dollar',
-            'numeric_code': 702,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SHP: {
-            'display_name': 'Saint Helena Pound',
-            'numeric_code': 654,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SLL: {
-            'display_name': 'Leone',
-            'numeric_code': 694,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SOS: {
-            'display_name': 'Somali Shilling',
-            'numeric_code': 706,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SRD: {
-            'display_name': 'Surinam Dollar',
-            'numeric_code': 968,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SSP: {
-            'display_name': 'South Sudanese Pound',
-            'numeric_code': 728,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.STD: {
-            'display_name': 'Dobra',
-            'numeric_code': 678,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SVC: {
-            'display_name': 'El Salvador Colon',
-            'numeric_code': 222,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SYP: {
-            'display_name': 'Syrian Pound',
-            'numeric_code': 760,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.SZL: {
-            'display_name': 'Lilangeni',
-            'numeric_code': 748,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.THB: {
-            'display_name': 'Baht',
-            'numeric_code': 764,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TJS: {
-            'display_name': 'Somoni',
-            'numeric_code': 972,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TMT: {
-            'display_name': 'Turkmenistan New Manat',
-            'numeric_code': 934,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TND: {
-            'display_name': 'Tunisian Dinar',
-            'numeric_code': 788,
-            'default_fraction_digits': 3,
-            'sub_unit': 1000,
-        },
-        Currency.TOP: {
-            'display_name': 'Pa’anga',
-            'numeric_code': 776,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TRY: {
-            'display_name': 'Turkish Lira',
-            'numeric_code': 949,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TTD: {
-            'display_name': 'Trinidad and Tobago Dollar',
-            'numeric_code': 780,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TWD: {
-            'display_name': 'New Taiwan Dollar',
-            'numeric_code': 901,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.TZS: {
-            'display_name': 'Tanzanian Shilling',
-            'numeric_code': 834,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.UAH: {
-            'display_name': 'Hryvnia',
-            'numeric_code': 980,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.UGX: {
-            'display_name': 'Uganda Shilling',
-            'numeric_code': 800,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.USD: {
-            'display_name': 'US Dollar',
-            'numeric_code': 840,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.USN: {
-            'display_name': 'US Dollar (Next day)',
-            'numeric_code': 997,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.USS: {
-            'display_name': 'US Dollar (Same day)',
-            'numeric_code': 998,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.UYI: {
-            'display_name': 'Uruguay Peso en Unidades Indexadas (URUIURUI)',
-            'numeric_code': 940,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.UYU: {
-            'display_name': 'Peso Uruguayo',
-            'numeric_code': 858,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.UZS: {
-            'display_name': 'Uzbekistan Sum',
-            'numeric_code': 860,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.VEF: {
-            'display_name': 'Bolivar',
-            'numeric_code': 937,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.VND: {
-            'display_name': 'Dong',
-            'numeric_code': 704,
-            'default_fraction_digits': 0,
-            'sub_unit': 10,
-        },
-        Currency.VUV: {
-            'display_name': 'Vatu',
-            'numeric_code': 548,
-            'default_fraction_digits': 0,
-            'sub_unit': 1,
-        },
-        Currency.WST: {
-            'display_name': 'Tala',
-            'numeric_code': 882,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.XAF: {
-            'display_name': 'CFA Franc BEAC',
-            'numeric_code': 950,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XAG: {
-            'display_name': 'Silver',
-            'numeric_code': 961,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XAU: {
-            'display_name': 'Gold',
-            'numeric_code': 959,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XBA: {
-            'display_name': 'Bond Markets Unit European Composite Unit (EURCO)',
-            'numeric_code': 955,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XBB: {
-            'display_name': 'Bond Markets Unit European Monetary Unit (E.M.U.-6)',
-            'numeric_code': 956,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XBC: {
-            'display_name': 'Bond Markets Unit European Unit of Account 9 (E.U.A.-9)',
-            'numeric_code': 957,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XBD: {
-            'display_name': 'Bond Markets Unit European Unit of Account 17 (E.U.A.-17)',
-            'numeric_code': 958,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XCD: {
-            'display_name': 'East Caribbean Dollar',
-            'numeric_code': 951,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.XDR: {
-            'display_name': 'SDR (Special Drawing Right)',
-            'numeric_code': 960,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XFU: {
-            'display_name': 'UIC-Franc',
-            'numeric_code': 958,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XOF: {
-            'display_name': 'CFA Franc BCEAO',
-            'numeric_code': 952,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XPD: {
-            'display_name': 'Palladium',
-            'numeric_code': 964,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XPF: {
-            'display_name': 'CFP Franc',
-            'numeric_code': 953,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XPT: {
-            'display_name': 'Platinum',
-            'numeric_code': 962,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XSU: {
-            'display_name': 'Sucre',
-            'numeric_code': 994,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XTS: {
-            'display_name': 'Codes specifically reserved for testing purposes',
-            'numeric_code': 963,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.XUA: {
-            'display_name': 'ADB Unit of Account',
-            'numeric_code': 965,
-            'default_fraction_digits': 0,
-            'sub_unit': 100,
-        },
-        Currency.YER: {
-            'display_name': 'Yemeni Rial',
-            'numeric_code': 886,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ZAR: {
-            'display_name': 'Rand',
-            'numeric_code': 710,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ZMW: {
-            'display_name': 'Zambian Kwacha',
-            'numeric_code': 967,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        },
-        Currency.ZWL: {
-            'display_name': 'Zimbabwe Dollar',
-            'numeric_code': 932,
-            'default_fraction_digits': 2,
-            'sub_unit': 100,
-        }
-    }
-    """Data about currencies.
+class CurrencyBase(Enum):
+    # defining fields below is useful for type assist
+    display_name: str
+    numeric_code: int
+    default_fraction_digits: int
+    sub_unit: int
 
-    Taken from https://github.com/sebastianbergmann/money
+    def __new__(cls, currency_code: str, currency_dict_value: Dict[str, Any]):
+        obj = object.__new__(cls)
+        obj._value_ = currency_code
+        obj.display_name = currency_dict_value.get("display_name")
+        obj.numeric_code = currency_dict_value.get("numeric_code")
+        obj.default_fraction_digits = currency_dict_value.get("default_fraction_digits")
+        obj.sub_unit = currency_dict_value.get("sub_unit")
+        return obj
 
-    """
+    def symbol(self, locale: str = "en_US") -> str:
+        """Returns a string of the currency symbol formatted for the specified locale"""
+        return get_currency_symbol(self.value, locale)
 
-    @classmethod
-    def decimal_precision_for_currency(cls, currency: Currency) -> int:
-        """Returns the decimal precision for a currency (number of digits after the decimal)"""
 
-        return cls._CURRENCY_DATA[currency]['default_fraction_digits']
-
-    @classmethod
-    def sub_unit_for_currency(cls, currency: Currency) -> int:
-        """Returns the sub unit for a currency.
-        (eg, the subunit for USD is 100 because there are 100 cents in a dollar)
-
-        """
-        return cls._CURRENCY_DATA[currency]['sub_unit']
+Currency = CurrencyBase("Currency", {k: (k, v) for k, v in _CURRENCY_DATA.items()})

--- a/money/currency.py
+++ b/money/currency.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 from babel.numbers import get_currency_symbol
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,pointless-string-statement
 
 """
 Data about currencies.
@@ -1108,11 +1108,16 @@ _CURRENCY_DATA = {
 
 
 class CurrencyBase(Enum):
+    """
+    Base class for `Currency` Enum defining fields and methods for each Enum entry
+    """
+    # pylint: disable=invalid-name
     # defining fields below is useful for type assist
     display_name: str
     numeric_code: int
     default_fraction_digits: int
     sub_unit: int
+    # pylint: enable=invalid-name
 
     def __new__(cls, currency_code: str, currency_dict_value: Dict[str, Any]):
         obj = object.__new__(cls)

--- a/money/exceptions.py
+++ b/money/exceptions.py
@@ -1,15 +1,18 @@
 """Custom exceptions for money operations"""
 
-#pylint: disable=missing-docstring
+# pylint: disable=missing-docstring
+
 
 class InvalidAmountError(ValueError):
     def __init__(self):
-        super().__init__('Invalid amount for currency')
+        super().__init__("Invalid amount for currency")
+
 
 class CurrencyMismatchError(ValueError):
     def __init__(self):
-        super().__init__('Currencies must match')
+        super().__init__("Currencies must match")
+
 
 class InvalidOperandError(ValueError):
     def __init__(self):
-        super().__init__('Invalid operand types for operation')
+        super().__init__("Invalid operand types for operation")

--- a/money/money.py
+++ b/money/money.py
@@ -4,13 +4,17 @@ from typing import Union
 from decimal import Decimal, ROUND_HALF_UP
 from babel.numbers import format_currency
 from money.currency import Currency
-from money.currency import CurrencyHelper
-from money.exceptions import InvalidAmountError, CurrencyMismatchError, InvalidOperandError
+from money.exceptions import (
+    InvalidAmountError,
+    CurrencyMismatchError,
+    InvalidOperandError,
+)
+
 
 class Money:
     """Class representing a monetary amount"""
 
-    def __init__(self, amount: str, currency: Currency=Currency.USD) -> None:
+    def __init__(self, amount: str, currency: Currency = Currency.USD) -> None:
         self._amount = Decimal(amount)
         self._currency = currency
 
@@ -30,16 +34,14 @@ class Money:
         return self._currency
 
     @classmethod
-    def from_sub_units(cls, sub_units: int, currency: Currency=Currency.USD):
+    def from_sub_units(cls, sub_units: int, currency: Currency = Currency.USD):
         """Creates a Money instance from sub-units."""
-        sub_units_per_unit = CurrencyHelper.sub_unit_for_currency(currency)
-        return cls(Decimal(sub_units) / Decimal(sub_units_per_unit), currency)
+        return cls(Decimal(sub_units) / Decimal(currency.sub_unit), currency)
 
     @property
     def sub_units(self) -> int:
         """Converts the amount to sub-units"""
-        sub_units_per_unit = CurrencyHelper.sub_unit_for_currency(self.currency)
-        return int(self.amount * sub_units_per_unit)
+        return int(self.amount * self.currency.sub_unit)
 
     def __hash__(self) -> str:
         return hash((self._amount, self._currency))
@@ -47,84 +49,84 @@ class Money:
     def __repr__(self) -> str:
         return "{} {}".format(self._currency.name, self._amount)
 
-    def __lt__(self, other: 'Money') -> bool:
+    def __lt__(self, other: "Money") -> bool:
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.amount < other.amount
 
-    def __le__(self, other: 'Money') -> bool:
+    def __le__(self, other: "Money") -> bool:
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.amount <= other.amount
 
-    def __gt__(self, other: 'Money') -> bool:
+    def __gt__(self, other: "Money") -> bool:
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.amount > other.amount
 
-    def __ge__(self, other: 'Money') -> bool:
+    def __ge__(self, other: "Money") -> bool:
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.amount >= other.amount
 
-    def __eq__(self, other: 'Money') -> bool:
+    def __eq__(self, other: "Money") -> bool:
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.amount == other.amount
 
-    def __ne__(self, other: 'Money') -> bool:
+    def __ne__(self, other: "Money") -> bool:
         return not self == other
 
     def __bool__(self):
         return bool(self._amount)
 
-    def __add__(self, other: 'Money') -> 'Money':
+    def __add__(self, other: "Money") -> "Money":
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.__class__(str(self.amount + other.amount), self.currency)
 
-    def __radd__(self, other: 'Money') -> 'Money':
+    def __radd__(self, other: "Money") -> "Money":
         return self.__add__(other)
 
-    def __sub__(self, other: 'Money') -> 'Money':
+    def __sub__(self, other: "Money") -> "Money":
         if not isinstance(other, Money):
             raise InvalidOperandError
 
         self._assert_same_currency(other)
         return self.__class__(str(self.amount - other.amount), self.currency)
 
-    def __rsub__(self, other: 'Money') -> 'Money':
+    def __rsub__(self, other: "Money") -> "Money":
         return self.__sub__(other)
 
-    def __mul__(self, other: float) -> 'Money':
+    def __mul__(self, other: float) -> "Money":
         if isinstance(other, Money):
             raise InvalidOperandError
 
         amount = self._round(self._amount * Decimal(other), self._currency)
         return self.__class__(str(amount), self._currency)
 
-    def __rmul__(self, other: float) -> 'Money':
+    def __rmul__(self, other: float) -> "Money":
         return self.__mul__(other)
 
-    def __div__(self, other: float) -> 'Money':
+    def __div__(self, other: float) -> "Money":
         return self.__truediv__(other)
 
-    def __truediv__(self, other: Union['Money', float]) -> Union['Money', float]:
+    def __truediv__(self, other: Union["Money", float]) -> Union["Money", float]:
         if isinstance(other, Money):
             self._assert_same_currency(other)
-            if other.amount == Decimal('0'):
+            if other.amount == Decimal("0"):
                 raise ZeroDivisionError
             return float(self.amount / other.amount)
 
@@ -134,10 +136,10 @@ class Money:
             amount = self._round(self._amount / Decimal(other), self._currency)
             return self.__class__(str(amount), self._currency)
 
-    def __floordiv__(self, other: Union['Money', float]) -> Union['Money', float]:
+    def __floordiv__(self, other: Union["Money", float]) -> Union["Money", float]:
         if isinstance(other, Money):
             self._assert_same_currency(other)
-            if other.amount == Decimal('0'):
+            if other.amount == Decimal("0"):
                 raise ZeroDivisionError
             return float(self.amount // other.amount)
 
@@ -147,10 +149,10 @@ class Money:
             amount = self._round(self._amount // Decimal(other), self._currency)
             return self.__class__(str(amount), self._currency)
 
-    def __mod__(self, other: Union['Money', float]) -> Union['Money', float]:
+    def __mod__(self, other: Union["Money", float]) -> Union["Money", float]:
         if isinstance(other, Money):
             self._assert_same_currency(other)
-            if other.amount == Decimal('0'):
+            if other.amount == Decimal("0"):
                 raise ZeroDivisionError
             return float(self.amount % other.amount)
 
@@ -160,31 +162,31 @@ class Money:
             amount = self._round(self._amount % Decimal(other), self._currency)
             return self.__class__(str(amount), self._currency)
 
-    def __neg__(self) -> 'Money':
+    def __neg__(self) -> "Money":
         return self.__class__(str(-self._amount), self._currency)
 
-    def __pos__(self) -> 'Money':
+    def __pos__(self) -> "Money":
         return self.__class__(str(+self._amount), self._currency)
 
-    def __abs__(self) -> 'Money':
+    def __abs__(self) -> "Money":
         return self.__class__(str(abs(self._amount)), self._currency)
 
-    def format(self, locale: str='en_US') -> str:
+    def format(self, locale: str = "en_US") -> str:
         """Returns a string of the currency formatted for the specified locale"""
 
         return format_currency(self.amount, self.currency.name, locale=locale)
 
-    def _assert_same_currency(self, other: 'Money') -> None:
+    def _assert_same_currency(self, other: "Money") -> None:
         if self.currency != other.currency:
             raise CurrencyMismatchError
 
     @staticmethod
     def _round(amount: Decimal, currency: Currency) -> Decimal:
-        sub_units = CurrencyHelper.sub_unit_for_currency(currency)
         # rstrip is necessary because quantize treats 1. differently from 1.0
-        rounded_to_subunits = amount.quantize(Decimal(str(1 / sub_units).rstrip('0')),\
-                                              rounding=ROUND_HALF_UP)
-        decimal_precision = CurrencyHelper.decimal_precision_for_currency(currency)
-        return rounded_to_subunits.quantize(\
-                   Decimal(str(1 / (10 ** decimal_precision)).rstrip('0')),\
-                   rounding=ROUND_HALF_UP)
+        rounded_to_subunits = amount.quantize(
+            Decimal(str(1 / currency.sub_unit).rstrip("0")), rounding=ROUND_HALF_UP
+        )
+        return rounded_to_subunits.quantize(
+            Decimal(str(1 / (10 ** currency.default_fraction_digits)).rstrip("0")),
+            rounding=ROUND_HALF_UP,
+        )

--- a/money/money.py
+++ b/money/money.py
@@ -129,7 +129,6 @@ class Money:
             if other.amount == Decimal("0"):
                 raise ZeroDivisionError
             return float(self.amount / other.amount)
-
         else:
             if other == 0:
                 raise ZeroDivisionError
@@ -142,7 +141,6 @@ class Money:
             if other.amount == Decimal("0"):
                 raise ZeroDivisionError
             return float(self.amount // other.amount)
-
         else:
             if other == 0:
                 raise ZeroDivisionError

--- a/money/tests/test_currency.py
+++ b/money/tests/test_currency.py
@@ -1,17 +1,8 @@
 """Currency tests"""
 
-from decimal import Decimal
-import pytest
-from money.money import Money
 from money.currency import Currency
-from money.exceptions import (
-    InvalidAmountError,
-    CurrencyMismatchError,
-    InvalidOperandError,
-)
 
-# pylint: disable=unneeded-not,expression-not-assigned,no-self-use,missing-docstring
-# pylint: disable=misplaced-comparison-constant,singleton-comparison,too-many-public-methods
+# pylint: disable=no-self-use,missing-docstring
 
 
 class TestCurrency:

--- a/money/tests/test_currency.py
+++ b/money/tests/test_currency.py
@@ -1,0 +1,34 @@
+"""Currency tests"""
+
+from decimal import Decimal
+import pytest
+from money.money import Money
+from money.currency import Currency
+from money.exceptions import (
+    InvalidAmountError,
+    CurrencyMismatchError,
+    InvalidOperandError,
+)
+
+# pylint: disable=unneeded-not,expression-not-assigned,no-self-use,missing-docstring
+# pylint: disable=misplaced-comparison-constant,singleton-comparison,too-many-public-methods
+
+
+class TestCurrency:
+    """Currency tests"""
+
+    def test_currency_fields(self):
+        currency = Currency.AED
+        assert currency.name == "AED"
+        assert currency.value == "AED"
+        assert currency.display_name == "UAE Dirham"
+        assert currency.numeric_code == 784
+        assert currency.default_fraction_digits == 2
+        assert currency.sub_unit == 100
+
+    def test_currency_symbol(self):
+        currency = Currency.USD
+        assert currency.symbol() == "$"
+        assert currency.symbol("en_US") == "$"
+        assert currency.symbol("en_GB") == "US$"
+        assert currency.symbol("es_MX") == "USD"

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -4,242 +4,247 @@ from decimal import Decimal
 import pytest
 from money.money import Money
 from money.currency import Currency
-from money.exceptions import InvalidAmountError, CurrencyMismatchError, InvalidOperandError
+from money.exceptions import (
+    InvalidAmountError,
+    CurrencyMismatchError,
+    InvalidOperandError,
+)
 
 # pylint: disable=unneeded-not,expression-not-assigned,no-self-use,missing-docstring
 # pylint: disable=misplaced-comparison-constant,singleton-comparison,too-many-public-methods
+
 
 class TestMoney:
     """Money tests"""
 
     def test_construction(self):
-        money = Money('3.95')
-        assert money.amount == Decimal('3.95')
+        money = Money("3.95")
+        assert money.amount == Decimal("3.95")
         assert money.currency == Currency.USD
 
-        money = Money('1', Currency.USD)
-        assert money.amount == Decimal('1')
+        money = Money("1", Currency.USD)
+        assert money.amount == Decimal("1")
         assert money.currency == Currency.USD
 
-        money = Money('199', Currency.JPY)
-        assert money.amount == Decimal('199')
+        money = Money("199", Currency.JPY)
+        assert money.amount == Decimal("199")
         assert money.currency == Currency.JPY
 
-        money = Money('192.325', Currency.KWD)
-        assert money.amount == Decimal('192.325')
+        money = Money("192.325", Currency.KWD)
+        assert money.amount == Decimal("192.325")
         assert money.currency == Currency.KWD
 
         with pytest.raises(InvalidAmountError):
-            Money('3.956', Currency.USD)
+            Money("3.956", Currency.USD)
 
         with pytest.raises(InvalidAmountError):
             # nonfractional currency
-            Money('10.2', Currency.KRW)
+            Money("10.2", Currency.KRW)
 
     def test_from_sub_units(self):
         money = Money.from_sub_units(101, Currency.USD)
-        assert money == Money('1.01', Currency.USD)
+        assert money == Money("1.01", Currency.USD)
 
         money = Money.from_sub_units(5, Currency.JPY)
-        assert money == Money('5', Currency.JPY)
+        assert money == Money("5", Currency.JPY)
 
     def test_sub_units(self):
-        money = Money('1.01', Currency.USD)
+        money = Money("1.01", Currency.USD)
         assert money.sub_units == 101
 
     def test_hash(self):
-        assert hash(Money('1.2')) == hash(Money('1.2', Currency.USD))
-        assert hash(Money('1.5')) != hash(Money('9.3'))
-        assert hash(Money('99.3', Currency.CHF)) != hash(Money('99.3', Currency.USD))
+        assert hash(Money("1.2")) == hash(Money("1.2", Currency.USD))
+        assert hash(Money("1.5")) != hash(Money("9.3"))
+        assert hash(Money("99.3", Currency.CHF)) != hash(Money("99.3", Currency.USD))
 
     def test_tostring(self):
-        assert str(Money('1.2')) == 'USD 1.2'
-        assert str(Money('3.6', Currency.CHF)) == 'CHF 3.6'
-        assert str(Money('88', Currency.JPY)) == 'JPY 88'
+        assert str(Money("1.2")) == "USD 1.2"
+        assert str(Money("3.6", Currency.CHF)) == "CHF 3.6"
+        assert str(Money("88", Currency.JPY)) == "JPY 88"
 
     def test_less_than(self):
-        assert Money('1.2') < Money('3.5')
-        assert not Money('104.2') < Money('5.13')
-        assert not Money('2.2') < Money('2.2')
+        assert Money("1.2") < Money("3.5")
+        assert not Money("104.2") < Money("5.13")
+        assert not Money("2.2") < Money("2.2")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('1.2', Currency.GBP) < Money('3.5', Currency.EUR)
+            Money("1.2", Currency.GBP) < Money("3.5", Currency.EUR)
 
         with pytest.raises(InvalidOperandError):
-            1.2 < Money('3.5')
+            1.2 < Money("3.5")
 
     def test_less_than_or_equal(self):
-        assert Money('1.2') <= Money('3.5')
-        assert not Money('104.2') <= Money('5.13')
-        assert Money('2.2') <= Money('2.2')
+        assert Money("1.2") <= Money("3.5")
+        assert not Money("104.2") <= Money("5.13")
+        assert Money("2.2") <= Money("2.2")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('1.2', Currency.GBP) <= Money('3.5', Currency.EUR)
+            Money("1.2", Currency.GBP) <= Money("3.5", Currency.EUR)
 
         with pytest.raises(InvalidOperandError):
-            1.2 <= Money('3.5')
+            1.2 <= Money("3.5")
 
     def test_greater_than(self):
-        assert Money('3.5') > Money('1.2')
-        assert not Money('5.13') > Money('104.2')
-        assert not Money('2.2') > Money('2.2')
+        assert Money("3.5") > Money("1.2")
+        assert not Money("5.13") > Money("104.2")
+        assert not Money("2.2") > Money("2.2")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) > Money('1.2', Currency.GBP)
+            Money("3.5", Currency.EUR) > Money("1.2", Currency.GBP)
 
         with pytest.raises(InvalidOperandError):
-            Money('3.5') > 1.2
+            Money("3.5") > 1.2
 
     def test_greater_than_or_equal(self):
-        assert Money('3.5') >= Money('1.2')
-        assert not Money('5.13') >= Money('104.2')
-        assert Money('2.2') >= Money('2.2')
+        assert Money("3.5") >= Money("1.2")
+        assert not Money("5.13") >= Money("104.2")
+        assert Money("2.2") >= Money("2.2")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) >= Money('1.2', Currency.GBP)
+            Money("3.5", Currency.EUR) >= Money("1.2", Currency.GBP)
 
         with pytest.raises(InvalidOperandError):
-            Money('3.5') >= 1.2
+            Money("3.5") >= 1.2
 
     def test_equal(self):
-        assert Money('3.5') == Money('3.5')
-        assert Money('4.0', Currency.GBP) == Money('4.0', Currency.GBP)
-        assert not Money('6.9') == Money('43')
+        assert Money("3.5") == Money("3.5")
+        assert Money("4.0", Currency.GBP) == Money("4.0", Currency.GBP)
+        assert not Money("6.9") == Money("43")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) == Money('3.5', Currency.GBP)
+            Money("3.5", Currency.EUR) == Money("3.5", Currency.GBP)
 
         with pytest.raises(InvalidOperandError):
-            Money('5.5') == 5.5
+            Money("5.5") == 5.5
 
     def test_not_equal(self):
-        assert Money('3.5') != Money('46.44')
-        assert Money('4.0', Currency.GBP) != Money('12.01', Currency.GBP)
-        assert not Money('6.9') != Money('6.9')
+        assert Money("3.5") != Money("46.44")
+        assert Money("4.0", Currency.GBP) != Money("12.01", Currency.GBP)
+        assert not Money("6.9") != Money("6.9")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) != Money('23', Currency.GBP)
+            Money("3.5", Currency.EUR) != Money("23", Currency.GBP)
 
         with pytest.raises(InvalidOperandError):
-            Money('5.5') != 666.32
+            Money("5.5") != 666.32
 
     def test_bool(self):
-        assert bool(Money('3.62')) == True
-        assert bool(Money('0.00')) == False
+        assert bool(Money("3.62")) == True
+        assert bool(Money("0.00")) == False
 
     def test_add(self):
-        assert Money('3.5') + Money('1.25') == Money('4.75')
+        assert Money("3.5") + Money("1.25") == Money("4.75")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) + Money('23', Currency.GBP)
+            Money("3.5", Currency.EUR) + Money("23", Currency.GBP)
 
         with pytest.raises(InvalidOperandError):
-            Money('5.5') + 666.32
+            Money("5.5") + 666.32
 
         with pytest.raises(InvalidOperandError):
-            666.32 + Money('5.5')
+            666.32 + Money("5.5")
 
     def test_subtract(self):
-        assert Money('3.5') - Money('1.25') == Money('2.25')
-        assert Money('4') - Money('5.5') == Money('-1.5')
+        assert Money("3.5") - Money("1.25") == Money("2.25")
+        assert Money("4") - Money("5.5") == Money("-1.5")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) - Money('1.8', Currency.GBP)
+            Money("3.5", Currency.EUR) - Money("1.8", Currency.GBP)
 
         with pytest.raises(InvalidOperandError):
-            Money('5.5') - 6.32
+            Money("5.5") - 6.32
 
         with pytest.raises(InvalidOperandError):
-            666.32 - Money('5.5')
+            666.32 - Money("5.5")
 
     def test_multiply(self):
-        assert Money('3.2') * 3 == Money('9.6')
-        assert 3 * Money('3.2', Currency.EUR) == Money('9.6', Currency.EUR)
-        assert Money('9.95') * 0.15 == Money('1.49')
-        assert Money('3', Currency.JPY) * 0.2 == Money('1', Currency.JPY)
-        assert Money('3', Currency.KRW) * 1.5 == Money('5', Currency.KRW)
+        assert Money("3.2") * 3 == Money("9.6")
+        assert 3 * Money("3.2", Currency.EUR) == Money("9.6", Currency.EUR)
+        assert Money("9.95") * 0.15 == Money("1.49")
+        assert Money("3", Currency.JPY) * 0.2 == Money("1", Currency.JPY)
+        assert Money("3", Currency.KRW) * 1.5 == Money("5", Currency.KRW)
 
         # since GNF has different subunits than JPY, the results are different even though
         # they have the same final decimal precision. hopefully this behavior is correct...
-        assert Money('3', Currency.JPY) * 1.4995 == Money('4', Currency.JPY)
-        assert Money('3', Currency.GNF) * 1.4995 == Money('5', Currency.GNF)
+        assert Money("3", Currency.JPY) * 1.4995 == Money("4", Currency.JPY)
+        assert Money("3", Currency.GNF) * 1.4995 == Money("5", Currency.GNF)
 
         with pytest.raises(InvalidOperandError):
-            Money('5.5') * Money('1.2')
+            Money("5.5") * Money("1.2")
 
     def test_divide(self):
-        assert Money('3.3') / 3 == Money('1.1')
-        assert Money('9.95') / 0.24 == Money('41.46')
-        assert Money('3', Currency.JPY) / 1.6 == Money('2', Currency.JPY)
-        assert Money('3.6') / Money('2.5') == 1.44
+        assert Money("3.3") / 3 == Money("1.1")
+        assert Money("9.95") / 0.24 == Money("41.46")
+        assert Money("3", Currency.JPY) / 1.6 == Money("2", Currency.JPY)
+        assert Money("3.6") / Money("2.5") == 1.44
 
         with pytest.raises(TypeError):
-            3 / Money('5.5')
+            3 / Money("5.5")
 
         with pytest.raises(ZeroDivisionError):
-            Money('3') / 0
+            Money("3") / 0
 
         with pytest.raises(ZeroDivisionError):
-            Money('3.3') / 0.0
+            Money("3.3") / 0.0
 
         with pytest.raises(ZeroDivisionError):
-            Money('3.3') / Money('0')
+            Money("3.3") / Money("0")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) / Money('1.8', Currency.GBP)
+            Money("3.5", Currency.EUR) / Money("1.8", Currency.GBP)
 
     def test_floor_divide(self):
-        assert Money('3.3') // 3 == Money('1')
-        assert Money('9.95') // 0.24 == Money('41')
-        assert Money('3', Currency.JPY) // 1.6 == Money('1', Currency.JPY)
-        assert Money('3.6') // Money('2.5') == 1
+        assert Money("3.3") // 3 == Money("1")
+        assert Money("9.95") // 0.24 == Money("41")
+        assert Money("3", Currency.JPY) // 1.6 == Money("1", Currency.JPY)
+        assert Money("3.6") // Money("2.5") == 1
 
         with pytest.raises(TypeError):
-            3 // Money('5.5')
+            3 // Money("5.5")
 
         with pytest.raises(ZeroDivisionError):
-            Money('3') // 0
+            Money("3") // 0
 
         with pytest.raises(ZeroDivisionError):
-            Money('3.3') // 0.0
+            Money("3.3") // 0.0
 
         with pytest.raises(ZeroDivisionError):
-            Money('3.3') // Money('0')
+            Money("3.3") // Money("0")
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) // Money('1.8', Currency.GBP)
+            Money("3.5", Currency.EUR) // Money("1.8", Currency.GBP)
 
     def test_mod(self):
-        assert Money('3.3') % 3 == Money('0.3')
-        assert Money('3', Currency.JPY) % 2 == Money('1', Currency.JPY)
-        assert Money('3') % Money('2') == 1
+        assert Money("3.3") % 3 == Money("0.3")
+        assert Money("3", Currency.JPY) % 2 == Money("1", Currency.JPY)
+        assert Money("3") % Money("2") == 1
 
         with pytest.raises(TypeError):
-            3 % Money('5.5')
+            3 % Money("5.5")
 
         with pytest.raises(ZeroDivisionError):
-            Money('3.3') % 0
+            Money("3.3") % 0
 
         with pytest.raises(ZeroDivisionError):
-            Money('3.3') % 0.0
+            Money("3.3") % 0.0
 
         with pytest.raises(CurrencyMismatchError):
-            Money('3.5', Currency.EUR) % Money('1.8', Currency.GBP)
+            Money("3.5", Currency.EUR) % Money("1.8", Currency.GBP)
 
     def test_neg(self):
-        assert -Money('5.23') == Money('-5.23')
-        assert -Money('-1.35') == Money('1.35')
+        assert -Money("5.23") == Money("-5.23")
+        assert -Money("-1.35") == Money("1.35")
 
     def test_pos(self):
-        assert +Money('5.23') == Money('5.23')
-        assert +Money('-1.35') == Money('-1.35')
+        assert +Money("5.23") == Money("5.23")
+        assert +Money("-1.35") == Money("-1.35")
 
     def test_abs(self):
-        assert abs(Money('5.23')) == Money('5.23')
-        assert abs(Money('-1.35')) == Money('1.35')
+        assert abs(Money("5.23")) == Money("5.23")
+        assert abs(Money("-1.35")) == Money("1.35")
 
     def test_format(self):
-        assert Money('3.24').format() == '$3.24'
-        assert Money('5.56', Currency.EUR).format('en_UK') == '€5.56'
-        assert Money('10', Currency.JPY).format() == '¥10'
-        assert Money('94', Currency.JPY).format('ja_JP') == '￥94'
+        assert Money("3.24").format() == "$3.24"
+        assert Money("5.56", Currency.EUR).format("en_UK") == "€5.56"
+        assert Money("10", Currency.JPY).format() == "¥10"
+        assert Money("94", Currency.JPY).format("ja_JP") == "￥94"


### PR DESCRIPTION
1. Refactored currency enum to have fields, rather than using a helper method
2. Added a currency symbol helper method, that delegates the functionality to babel
3. Added test
4. Ran `black` for formatting