### PR TITLE
Update incorrect subunit for VND. 

### DIFF
--- a/money/currency.py
+++ b/money/currency.py
@@ -1146,7 +1146,7 @@ class CurrencyHelper:
             'display_name': 'Dong',
             'numeric_code': 704,
             'default_fraction_digits': 0,
-            'sub_unit': 10,
+            'sub_unit': 1,
         },
         Currency.VUV: {
             'display_name': 'Vatu',


### PR DESCRIPTION
The subunit for the VND currency is incorrect. This PR updates it from 10 to 1.

Sources for the correct subunit:

Facebook: https://developers.facebook.com/docs/marketing-api/currencies/ recommends subunit of 1
Adyen: https://docs.adyen.com/development-resources/currency-codes recommends 0 decimal