### PR TITLE
Fix: update more currency subunits

### DIFF
--- a/money/currency.py
+++ b/money/currency.py
@@ -1146,7 +1146,7 @@ class CurrencyHelper:
             'display_name': 'Dong',
             'numeric_code': 704,
             'default_fraction_digits': 0,
-            'sub_unit': 10,
+            'sub_unit': 1,
         },
         Currency.VUV: {
             'display_name': 'Vatu',

--- a/money/currency.py
+++ b/money/currency.py
@@ -588,7 +588,7 @@ class CurrencyHelper:
             'display_name': 'Rupiah',
             'numeric_code': 360,
             'default_fraction_digits': 2,
-            'sub_unit': 100,
+            'sub_unit': 1,
         },
         Currency.ILS: {
             'display_name': 'New Israeli Sheqel',

--- a/money/currency.py
+++ b/money/currency.py
@@ -438,7 +438,7 @@ class CurrencyHelper:
             'display_name': 'Cape Verde Escudo',
             'numeric_code': 132,
             'default_fraction_digits': 2,
-            'sub_unit': 100,
+            'sub_unit': 1,
         },
         Currency.CZK: {
             'display_name': 'Czech Koruna',

--- a/money/currency.py
+++ b/money/currency.py
@@ -396,7 +396,7 @@ class CurrencyHelper:
             'display_name': 'Chilean Peso',
             'numeric_code': 152,
             'default_fraction_digits': 0,
-            'sub_unit': 100,
+            'sub_unit': 1,
         },
         Currency.CNY: {
             'display_name': 'Yuan Renminbi',

--- a/money/currency.py
+++ b/money/currency.py
@@ -654,7 +654,7 @@ class CurrencyHelper:
             'display_name': 'Riel',
             'numeric_code': 116,
             'default_fraction_digits': 2,
-            'sub_unit': 100,
+            'sub_unit': 1,
         },
         Currency.KMF: {
             'display_name': 'Comoro Franc',

--- a/money/currency.py
+++ b/money/currency.py
@@ -450,7 +450,7 @@ class CurrencyHelper:
             'display_name': 'Djibouti Franc',
             'numeric_code': 262,
             'default_fraction_digits': 0,
-            'sub_unit': 100,
+            'sub_unit': 1,
         },
         Currency.DKK: {
             'display_name': 'Danish Krone',


### PR DESCRIPTION
The subunit for the CLP, CVE, DJF, IDR & KHR currencies are incorrect. This PR updates it from 10 to 1.

Previous PR: https://github.com/primer-io/py-money/pull/1